### PR TITLE
一些修正

### DIFF
--- a/Biotech/Keyed/Messages.xml
+++ b/Biotech/Keyed/Messages.xml
@@ -52,7 +52,7 @@
   <!-- EN: {0} has died because of a lack of pollution. -->
   <MessagePlantDiedOfNoPollution>{0}因为缺乏污染而死亡。</MessagePlantDiedOfNoPollution>
   <!-- EN: Pollution has increased by {0} at {1}. -->
-  <MessageWorldTilePollutionChanged>污染由于{0}增加了{1}。</MessageWorldTilePollutionChanged>
+  <MessageWorldTilePollutionChanged>在坐标{1}处的污染增加了{0}。</MessageWorldTilePollutionChanged>
   <!-- EN: A cocoon has been disturbed and is opening! -->
   <MessageCocoonDisturbed>一个虫茧被扰动了，它正在破茧!</MessageCocoonDisturbed>
   <!-- EN: Cocoons have been disturbed and are opening! -->

--- a/Core/DefInjected/ThinkTreeDef/Mechanoid.xml
+++ b/Core/DefInjected/ThinkTreeDef/Mechanoid.xml
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <LanguageData>
   
   <!-- EN: Patrolling. -->
-  <Mechanoid.thinkRoot.subNodes.6.subNodes.0.subNodes.1.subNodes.4.subNodes.1.subNodes.0.reportStringOverride>正在巡逻。</Mechanoid.thinkRoot.subNodes.6.subNodes.0.subNodes.1.subNodes.4.subNodes.1.subNodes.0.reportStringOverride>
+  <Mechanoid.thinkRoot.subNodes.7.subNodes.0.subNodes.1.subNodes.4.subNodes.1.subNodes.0.reportStringOverride>正在巡逻。</Mechanoid.thinkRoot.subNodes.7.subNodes.0.subNodes.1.subNodes.4.subNodes.1.subNodes.0.reportStringOverride>
   
 </LanguageData>

--- a/Core/Keyed/Misc_Gameplay.xml
+++ b/Core/Keyed/Misc_Gameplay.xml
@@ -985,7 +985,7 @@
   <!-- EN: Power output -->
   <PowerOutput>电力输出</PowerOutput>
   <!-- EN: {0} W when active -->
-  <PowerActiveNeeded>{0} W （激活）</PowerActiveNeeded> <!-- text_todo -->
+  <PowerActiveNeeded>{0} W （激活）</PowerActiveNeeded>
   <!-- EN: Stored -->
   <PowerBatteryStored>蓄电</PowerBatteryStored>
   <!-- EN: Efficiency -->


### PR DESCRIPTION
修正内容
1. 修复了当投放污染到其他地块时的左上角提示信息，原文为`Pollution has increased by {0} at {1}.`未正确翻译，目前翻译为`污染由于{0}增加了{1}。`，`{0}`变量代表污染增加量，`{1}`为坐标。
2. 修正"正在巡逻。"未实现翻译。
3. 删除了一处`<!-- text_todo -->`注释。

鉴于我在贴吧疯狂纠错没人鸟我，只能亲自上场提交。 😬 